### PR TITLE
Add ie10 test & formatToParts spec

### DIFF
--- a/karma.conf.saucelabs.js
+++ b/karma.conf.saucelabs.js
@@ -2,6 +2,11 @@
 
 module.exports = function(config) {
 	const customLaunchers = {
+		sl_ie_10: {
+			base: 'SauceLabs',
+			browserName: 'internet explorer',
+			version: '10'
+		},
 		sl_ie_11: {
 			base: 'SauceLabs',
 			browserName: 'internet explorer',
@@ -40,6 +45,6 @@ module.exports = function(config) {
 		browserNoActivityTimeout: 100000,
 		port: 9999,
 		singleRun: true,
-		browsers: ['sl_edge', 'sl_ie_11', 'sl_safari']
+		browsers: ['sl_ie_10', 'sl_edge', 'sl_ie_11', 'sl_safari']
 	});
 };

--- a/test/test-data/format-to-parts-fixtures.js
+++ b/test/test-data/format-to-parts-fixtures.js
@@ -1,0 +1,110 @@
+module.exports = [{
+// locale en
+	date: new Date('Mon Mar 06 2017 14:50:00 GMT'),
+	locale: 'en',
+	timeZone: 'America/Los_Angeles',
+	nameFormat: 'long',
+	expectedTimeZoneName: 'Pacific Standard Time'
+}, {
+	date: new Date('Sun Apr 30 2017 09:30:10 GMT'),
+	locale: 'en',
+	timeZone: 'America/Los_Angeles',
+	nameFormat: 'long',
+	expectedTimeZoneName: 'Pacific Daylight Time'
+},
+{
+	date: new Date('Mon Mar 06 2017 14:50:00 GMT'),
+	locale: 'en',
+	timeZone: 'America/Los_Angeles',
+	nameFormat: 'short',
+	expectedTimeZoneName: 'PST'
+},
+{
+	date: new Date('Sun Apr 30 2017 09:30:10 GMT'),
+	locale: 'en',
+	timeZone: 'America/Los_Angeles',
+	nameFormat: 'short',
+	expectedTimeZoneName: 'PDT'
+},
+{
+	date: new Date('Mon Mar 06 2017 14:50:00 GMT'),
+	locale: 'hi',
+	timeZone: 'America/Los_Angeles',
+	nameFormat: 'long',
+	expectedTimeZoneName: 'उत्तरी अमेरिकी प्रशांत मानक समय'
+}, {
+	date: new Date('Sun Apr 30 2017 09:30:10 GMT'),
+	locale: 'hi',
+	timeZone: 'America/Los_Angeles',
+	nameFormat: 'long',
+	expectedTimeZoneName: 'उत्तरी अमेरिकी प्रशांत डेलाइट समय'
+},
+{
+	date: new Date('Sun Apr 30 2017 09:30:10 GMT'),
+	locale: 'hi',
+	timeZone: 'America/Los_Angeles',
+	nameFormat: 'short',
+	expectedTimeZoneName: 'GMT-7'
+},
+{
+	date: new Date('Mon Mar 06 2017 14:50:00 GMT'),
+	locale: 'hi',
+	timeZone: 'America/Los_Angeles',
+	nameFormat: 'short',
+	expectedTimeZoneName: 'GMT-8'
+},
+{
+	date: new Date('Mon Mar 06 2017 14:50:00 GMT'),
+	locale: 'en',
+	timeZone: 'Asia/Calcutta',
+	nameFormat: 'long',
+	expectedTimeZoneName: 'India Standard Time'
+}, {
+	date: new Date('Sun Apr 30 2017 09:30:10 GMT'),
+	locale: 'en',
+	timeZone: 'Asia/Calcutta',
+	nameFormat: 'long',
+	expectedTimeZoneName: 'India Standard Time'
+},
+{
+	date: new Date('Sun Apr 30 2017 09:30:10 GMT'),
+	locale: 'en',
+	timeZone: 'Asia/Calcutta',
+	nameFormat: 'short',
+	expectedTimeZoneName: 'GMT+5:30'
+},
+{
+	date: new Date('Sun Apr 30 2017 09:30:10 GMT'),
+	locale: 'en',
+	timeZone: 'Asia/Calcutta',
+	nameFormat: 'short',
+	expectedTimeZoneName: 'GMT+5:30'
+},
+{
+	date: new Date('Mon Mar 06 2017 14:50:00 GMT'),
+	locale: 'hi',
+	timeZone: 'Asia/Calcutta',
+	nameFormat: 'long',
+	expectedTimeZoneName: 'भारतीय मानक समय'
+}, {
+	date: new Date('Sun Apr 30 2017 09:30:10 GMT'),
+	locale: 'hi',
+	timeZone: 'Asia/Calcutta',
+	nameFormat: 'long',
+	expectedTimeZoneName: 'भारतीय मानक समय'
+},
+{
+	date: new Date('Mon Mar 06 2017 14:50:00 GMT'),
+	locale: 'hi',
+	timeZone: 'Asia/Calcutta',
+	nameFormat: 'short',
+	expectedTimeZoneName: 'IST'
+},
+{
+	date: new Date('Sun Apr 30 2017 09:30:10 GMT'),
+	locale: 'hi',
+	timeZone: 'Asia/Calcutta',
+	nameFormat: 'short',
+	expectedTimeZoneName: 'IST'
+}
+];


### PR DESCRIPTION
 1. ie10 is crucial, because this will test polyfilling of intl.js polyfill.
 2. Added test for formatToParts.
    1. We must not implement formatToParts if not implemented in browser
    (or in intl.js polyfill)
    2. Add 16 Tests for 2 dates, 2 locales, 2 timezones and 2 formats.

formatToParts tests are skipped as of now. 