### PR TITLE
Fixing guard for DateTimeFormat polyfill

### DIFF
--- a/src/code/polyfill.js
+++ b/src/code/polyfill.js
@@ -60,7 +60,7 @@ function _inherits(subClass, superClass) {
 * https://tc39.github.io/ecma402/#sec-Intl.DateTimeFormat.prototype.format
 */
 export default function polyfill(globalSpace) {
-    if (!(globalSpace.Intl && globalSpace.Intl.DateTimeFormat && !globalSpace.Intl._DateTimeFormatTimeZone)) {
+    if (globalSpace.Intl && (globalSpace.Intl.DateTimeFormat || globalSpace.Intl._DateTimeFormatTimeZone)) {
         return;
     }
 


### PR DESCRIPTION
The polyfill will fail in IE9 since `window.Intl` is not defined.
The previous polyfill guard was incorrect since it will never return false.