### PR TITLE
Fix TZ aliases not working

### DIFF
--- a/tasks/gen-package.js
+++ b/tasks/gen-package.js
@@ -361,8 +361,8 @@ function generatePackages(grunt) {
 
 	packages.forEach(pkg => {
 		const list = files.
-		concat(getTimeZoneList(pkg.timeZoneListType).map(p => srcBase + p)).
-		concat(getLocaleList(pkg.localeListType).map(p => srcBase + p));
+		concat(getLocaleList(pkg.localeListType).map(p => srcBase + p)).
+		concat(getTimeZoneList(pkg.timeZoneListType).map(p => srcBase + p));
 
 		grunt.file.write(`${buildDir}/src/${pkg.name}.js`, Utill.getPolyfillPackageModule(list));
 	});


### PR DESCRIPTION
Currently, when the timezone data is loaded, the loading function tries to [enrich the metazone data](https://github.com/yahoo/date-time-format-timezone/blob/master/src/code/data-loader.js#L217) which will allow for name aliases of the timezone to refer to the same metazone.

Unfortunately, the build script was concatenating the imports incorrectly so the TZ data was imported before the metazone data [so the matching metazone was never found](https://github.com/yahoo/date-time-format-timezone/blob/master/src/code/data-loader.js#L229).

It's not possible (in my understanding of the code base) to write a test to assert this behaviour. In the tests, the `metazone` is run before the `tzdata` so it is in the correct order.

Before:

```js
// build/src/index.js
/*
 * Copyright 2017, Yahoo Inc.
 * Copyrights licensed under the New BSD License.
 * See the accompanying LICENSE file for terms.
 */
var myGlobal = (typeof global !== "undefined" && {}.toString.call(global) === '[object global]') ? global : window;
(require('./code/polyfill.js').default)(myGlobal);
(require('./code/data-loader.js').default)(myGlobal);
(require('./data/tzdata.js'))(myGlobal);
(require('./data/metazone.js'))(myGlobal);
(require('./data/locale.js'))(myGlobal);
module.exports = myGlobal.Intl.DateTimeFormat;
```

After:

```js
// build/src/index.js
/*
 * Copyright 2017, Yahoo Inc.
 * Copyrights licensed under the New BSD License.
 * See the accompanying LICENSE file for terms.
 */
var myGlobal = (typeof global !== "undefined" && {}.toString.call(global) === '[object global]') ? global : window;
(require('./code/polyfill.js').default)(myGlobal);
(require('./code/data-loader.js').default)(myGlobal);
(require('./data/metazone.js'))(myGlobal);
(require('./data/locale.js'))(myGlobal);
(require('./data/tzdata.js'))(myGlobal);
module.exports = myGlobal.Intl.DateTimeFormat;
```