### PR TITLE
Fix markup on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,29 +7,29 @@ Some [browsers do not support arbitrary time zone ](http://kangax.github.io/comp
 
 ## How to use?
 
-   1. install
-
-	`npm i date-time-format-timezone`
-
-   1. nodejs
-
-	`require('date-time-format-timezone'); // polyfill is ready`
-
-   1. browser
-
-for everything 
+1. Install via nodejs:
 ```
-   <script src="https://unpkg.com/date-time-format-timezone@latest/build/browserified/date-time-format-timezone-complete-min.js">
+npm i date-time-format-timezone
 ```
-  or
-for individual files 
+And then import in your code:
+```
+require('date-time-format-timezone'); // polyfill is ready
+```
 
-  ```
-    <script src="https://unpkg.com/date-time-format-timezone@latest/build/browserified/date-time-format-time-zone-no-data.js">
-    <script src="https://unpkg.com/date-time-format-timezone@latest/build/browserified/data/locales/locale-en-US-POSIX.js">
-    <script src="https://unpkg.com/date-time-format-timezone@latest/build/browserified/data/metazone.js">
-    <script src="https://unpkg.com/date-time-format-timezone@latest/build/browserified/data/timezones/tzdata-america-los_angeles.js">
-  ```
+2. In the browser
+
+include everything:
+```
+<script src="https://unpkg.com/date-time-format-timezone@latest/build/browserified/date-time-format-timezone-complete-min.js">
+```
+or include individual files:
+
+```
+<script src="https://unpkg.com/date-time-format-timezone@latest/build/browserified/date-time-format-time-zone-no-data.js">
+<script src="https://unpkg.com/date-time-format-timezone@latest/build/browserified/data/locales/locale-en-US-POSIX.js">
+<script src="https://unpkg.com/date-time-format-timezone@latest/build/browserified/data/metazone.js">
+<script src="https://unpkg.com/date-time-format-timezone@latest/build/browserified/data/timezones/tzdata-america-los_angeles.js">
+ ```
 This polyfill can add this support.
 
 ```javascript


### PR DESCRIPTION
The readme currently has extraneous backticks in the code samples and has three bullets that say 1. This PR would fix those issues

See what it looks like when rendered here: https://github.com/benmccann/date-time-format-timezone/tree/markup