### PR TITLE
Use native object for formatToParts

### DIFF
--- a/karma.conf.saucelabs.js
+++ b/karma.conf.saucelabs.js
@@ -20,6 +20,11 @@ module.exports = function(config) {
 		sl_edge: {
 			base: 'SauceLabs',
 			browserName: 'microsoftedge'
+		},
+		sl_firefox: {
+			base: 'SauceLabs',
+			browserName: 'firefox',
+			version: '64'
 		}
 	};
 
@@ -45,6 +50,6 @@ module.exports = function(config) {
 		browserNoActivityTimeout: 100000,
 		port: 9999,
 		singleRun: true,
-		browsers: ['sl_ie_10', 'sl_edge', 'sl_ie_11', 'sl_safari']
+		browsers: ['sl_ie_10', 'sl_edge', 'sl_ie_11', 'sl_safari', 'sl_firefox']
 	});
 };

--- a/src/code/polyfill.js
+++ b/src/code/polyfill.js
@@ -90,12 +90,20 @@ export default function polyfill(globalSpace) {
             // we don't need to format arbitrary timezone
             _DateTimeFormat.call(this, locale, options);
 
+            if (this.formatToParts) {
+                this._nativeObject = new _DateTimeFormat(locale, options);
+            }
+
             return;
         }
 
         if (checkTimeZoneSupport(timeZone)) {
             // native method has support for timezone. no polyfill logic needed.
             _DateTimeFormat.call(this, locale, options);
+
+            if (this.formatToParts) {
+                this._nativeObject = new _DateTimeFormat(locale, options);
+            }
 
             return;
         }
@@ -229,8 +237,8 @@ export default function polyfill(globalSpace) {
                   this
                 );
 
-                if (!this._dateTimeFormatPolyfill) {
-                    return _formatToParts.call(this, date);
+                if (!this._dateTimeFormatPolyfill && this._nativeObject) {
+                    return this._nativeObject.formatToParts(date);
                 }
 
                 if (date === null || date === undefined) {


### PR DESCRIPTION
I noticed tests are filing on latest firefox, I just fixed by using native object for formatToParts.